### PR TITLE
Add CI workflow for checks

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -14,24 +14,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Install the latest version of rye
+        uses: eifinger/setup-rye@v4
         with:
-          python-version: '3.12'
+          enable-cache: true
 
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements-dev.lock
+      - name: Rye dependencies
+        run: rye sync
 
-      - name: Formatting check
-        run: black --check src tests
+      - name: Formatting
+        run: rye run format-check
 
       - name: Linting
-        run: ruff check src tests
+        run: rye run lint
 
-      - name: Type checking
-        run: pyright src
+      - name: Pyright linting
+        run: rye run typecheck
 
       - name: Run tests
-        run: pytest
+        run: rye run test

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.lock
+
+      - name: Formatting check
+        run: black --check src tests
+
+      - name: Linting
+        run: ruff check src tests
+
+      - name: Type checking
+        run: pyright src
+
+      - name: Run tests
+        run: pytest


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow that installs dependencies and runs formatting check, linting, type checking, and tests

## Testing
- `pre-commit run --files .github/workflows/ci-checks.yml` *(fails: command not found)*
- `PYENV_VERSION=3.12.10 black --check src tests`
- `PYENV_VERSION=3.12.10 ruff check src tests`
- `PYENV_VERSION=3.12.10 pyright --version` *(fails: missing imports)*
- `PYENV_VERSION=3.12.10 python -m pytest` *(fails: ModuleNotFoundError: No module named 'mcp')*

------
https://chatgpt.com/codex/tasks/task_e_68ad1cdb458c832b8b40306d6b5b7aef